### PR TITLE
[codex] Fix linked worktree session namespace drift

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,7 @@ node_modules/**
 cli/**
 cli_backup/**
 .sisyphus/**
+.omx/**
 .github/**
 docs/**
 scripts/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ This document serves as the primary rule file for AI Agents working on this proj
 - **Path Handling**: Use `getWorktreePath(item)` helper.
 - **Canonical Path Matching**: For path equality/deduplication/current-workspace checks, normalize to absolute paths with `~` expansion before comparison (do not collapse symlink aliases via `realpath`).
 - **Managed Worktree Location**: Create extension-managed worktrees under `~/.tmux-worktrees/<repo-name-hash>/` by default. Reuse shared helpers for path checks and orphan cleanup instead of hardcoding repo-local `.worktrees` path fragments.
-- **Session Namespace**: Build tmux session prefixes from repo-root identity (basename + short path hash), not display repo name alone, to avoid collisions across same-name repositories in different directories.
+- **Session Namespace**: Build tmux session prefixes from primary-worktree identity (basename + short path hash), not the current VS Code workspace folder or display repo name alone, to avoid collisions and linked-worktree drift. Use the shared async identity helpers instead of calling `getRepoRoot()` directly for namespace or managed-dir names.
 - **Zellij Leading-Dash Session Names**: Repo basenames such as `.hermes` can produce session names beginning with `-`. When passing those names to Zellij as positional arguments, insert `--`; shell quoting alone does not stop Zellij from parsing them as CLI flags.
 - **Legacy Session Compatibility Isolation**: Keep legacy session-prefix compatibility logic centralized in `src/utils/sessionCompatibility.ts`; call helpers from commands/providers instead of duplicating fallback checks.
 - **Root Detection**: Determine the primary worktree by comparing worktree path to the primary worktree path derived from `git rev-parse --git-common-dir`, not by branch naming, folder basename, or the current workspace folder.
@@ -57,6 +57,7 @@ This document serves as the primary rule file for AI Agents working on this proj
 - **Zellij Keybindings**: Manage Zellij passthrough shortcuts from `scripts/generate-zellij-keybindings.mjs`; do not hand-edit the generated `workbench.action.terminal.sendSequence` entries in `package.json`. Add new passthroughs to the script's `ZELLIJ_KEY_PASSTHROUGHS` list, prefer VS Code scan-code key strings for layout independence, then run `npm run generate:zellij-keybindings`. Keep all generated entries scoped to `terminalFocus && config.tmuxWorktree.multiplexer == 'zellij'`. Apply VS Code terminal setting overrides from `src/utils/zellijTerminalSettings.ts` only while the Zellij backend is active, then restore extension-applied global values when switching away.
 - **Zellij Control-Key Passthroughs**: Use literal control/escape sequences in `ZELLIJ_KEY_PASSTHROUGHS` so VS Code forwards the intended byte to the terminal. Prefer scan-code key strings for control and Alt shortcuts so Korean IME/layout variants map to the intended physical key without duplicate Hangul-specific bindings.
 - **No-Git Workspace Labeling**: If the workspace is not a git worktree, the tree must still show one primary item labeled `current project (no git)` mapped to the current workspace path.
+- **Package Hygiene**: Keep local orchestration/runtime state such as `.omx/` out of VSIX packages via `.vscodeignore`; git excludes alone do not affect packaging.
 
 ## 3. Documentation & Development
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ Detect and clean up tmux sessions that no longer have matching worktrees. Keep y
 | `TMUX: Change Session File Directory` | Change where tmux/zellij IPC sockets are stored (default `/var/tmp`) |
 | `TMUX: Sync Session File Directory to Shell rc` | Write `TMUX_TMPDIR`/`ZELLIJ_SOCKET_DIR` exports to your shell rc so external tmux/zellij use the same dir |
 
-## Recent Updates (v1.1.2 - v1.2.8)
+## Recent Updates (v1.1.2 - v1.2.12)
 
+- **v1.2.12**: Fixed session namespace stability when VS Code is opened from a linked worktree; session names and managed worktree paths now stay anchored to the primary worktree.
 - **v1.2.8**: Fixed Zellij attach for session names beginning with `-`, which can happen in Remote-SSH workspaces opened from hidden folders such as `.hermes`.
 - **v1.1.6**: Added image-aware terminal paste for AI CLI workflows (`Cmd+V` / `Ctrl+Shift+V`) and a force image paste command. Also improved startup auto-attach sizing stability to reduce occasional small terminal rendering until a manual window resize, fixed persistent clipping by restoring `window-size latest` after forced pre-attach resize, and fixed a shell-script parsing regression that could fail attach launch in some environments.
 - **v1.1.4 - v1.1.5**: Improved tmux clipboard reliability by enabling clipboard capabilities and passthrough options during attach.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -116,8 +116,9 @@ tmux attach -t myapp/feature-oauth
 | `TMUX: Smart Paste (Image Support)` | 스마트 터미널 붙여넣기: 텍스트는 일반 paste, 이미지는 임시 파일 경로 입력 |
 | `TMUX: Paste Image from Clipboard` | 클립보드 이미지를 강제로 저장하고 현재 터미널에 경로 입력 |
 
-## 최근 업데이트 (v1.1.2 - v1.2.8)
+## 최근 업데이트 (v1.1.2 - v1.2.12)
 
+- **v1.2.12**: VS Code를 linked worktree에서 열었을 때 세션 namespace가 흔들리던 문제를 수정했습니다. 세션명과 관리형 worktree 경로가 이제 primary worktree 기준으로 고정됩니다.
 - **v1.2.8**: `.hermes`처럼 숨김 폴더에서 열린 Remote-SSH workspace에서 `-`로 시작하는 Zellij 세션명을 attach할 때 help가 뜨고 바로 종료되던 문제를 수정했습니다.
 - **v1.1.6**: AI CLI 워크플로우를 위한 이미지 인식 터미널 붙여넣기(`Cmd+V` / `Ctrl+Shift+V`)와 강제 이미지 붙여넣기 명령 추가. 또한 시작 시 auto-attach 타이밍을 보정해, 가끔 터미널이 작게 렌더링되었다가 창 크기 조절 후 정상화되던 문제를 완화했고, 강제 resize 이후 `window-size latest`를 복구해 지속적인 화면 잘림을 줄였으며, 일부 환경에서 attach 실행이 실패하던 셸 스크립트 파싱 회귀도 수정했습니다.
 - **v1.1.4 - v1.1.5**: tmux attach 시 클립보드/패스스루 옵션을 자동 설정해 원격 환경 클립보드 신뢰성 개선.

--- a/src/commands/attachCreate.ts
+++ b/src/commands/attachCreate.ts
@@ -8,7 +8,7 @@ async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {
   const backend = getActiveBackend();
   const sessions = await backend.listSessions();
   const matchingSessions: string[] = [];
-  const sessionPrefixConfig = createRepoSessionPrefixConfig(repoRoot);
+  const sessionPrefixConfig = await createRepoSessionPrefixConfig(repoRoot);
   const repoPrefix = sessionPrefixConfig.primaryPrefix;
 
   for (const session of sessions) {

--- a/src/commands/autoAttach.ts
+++ b/src/commands/autoAttach.ts
@@ -15,7 +15,7 @@ export async function autoAttachOnStartup(): Promise<void> {
 
   const backend = getActiveBackend();
   const repoRoot = workspaceFolders[0].uri.fsPath;
-  const sessionPrefixConfig = createRepoSessionPrefixConfig(repoRoot);
+  const sessionPrefixConfig = await createRepoSessionPrefixConfig(repoRoot);
   const repoPrefix = sessionPrefixConfig.primaryPrefix;
 
   const sessions = await backend.listSessions();

--- a/src/commands/createWorktreeFromBranch.ts
+++ b/src/commands/createWorktreeFromBranch.ts
@@ -51,7 +51,7 @@ export async function createWorktreeFromBranch(item: WorktreeItem | undefined): 
   let repoSessionNamespace: string;
   try {
     repoRoot = getRepoRoot();
-    repoSessionNamespace = getRepoSessionNamespace(repoRoot);
+    repoSessionNamespace = await getRepoSessionNamespace(repoRoot);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     vscode.window.showErrorMessage(`Failed: ${message}`);

--- a/src/commands/newTask.ts
+++ b/src/commands/newTask.ts
@@ -22,7 +22,7 @@ export async function newTask(): Promise<void> {
   let repoSessionNamespace: string;
   try {
     repoRoot = getRepoRoot();
-    repoSessionNamespace = getRepoSessionNamespace(repoRoot);
+    repoSessionNamespace = await getRepoSessionNamespace(repoRoot);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     vscode.window.showErrorMessage(`Failed to create task: ${message}`);

--- a/src/commands/orphanCleanup.ts
+++ b/src/commands/orphanCleanup.ts
@@ -11,7 +11,7 @@ export async function cleanupOrphans(): Promise<void> {
   try {
     const backend = getActiveBackend();
     const repoRoot = getRepoRoot();
-    const sessionPrefixConfig = createRepoSessionPrefixConfig(repoRoot);
+    const sessionPrefixConfig = await createRepoSessionPrefixConfig(repoRoot);
     
     const allSessions = await backend.listSessions();
     const repoPrefix = sessionPrefixConfig.primaryPrefix;
@@ -44,7 +44,7 @@ export async function cleanupOrphans(): Promise<void> {
     const worktreeOnly: string[] = [];
     for (const wt of worktrees) {
       const normalizedWorktreePath = toCanonicalPath(wt.path) || path.resolve(wt.path);
-      if (isManagedWorktreePath(repoRoot, wt.path) && !sessionWorkdirs.has(normalizedWorktreePath)) {
+      if (await isManagedWorktreePath(repoRoot, wt.path) && !sessionWorkdirs.has(normalizedWorktreePath)) {
         worktreeOnly.push(wt.path);
       }
     }

--- a/src/commands/removeTask.ts
+++ b/src/commands/removeTask.ts
@@ -89,7 +89,7 @@ export async function removeTask(item: TmuxItem): Promise<void> {
   try {
     const repoRoot = getRepoRoot();
     branchName = worktreePath ? await getWorktreeBranch(repoRoot, worktreePath) : undefined;
-    const sessionPrefixConfig = createRepoSessionPrefixConfig(repoRoot);
+    const sessionPrefixConfig = await createRepoSessionPrefixConfig(repoRoot);
     slug = slug || extractRepoSessionSlug(sessionName, sessionPrefixConfig, { allowLegacy: true });
   } catch {
     void 0;

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createHash } from 'crypto';
 import { exec } from '../utils/exec';
-import { getRepoRoot, getRepoName, listWorktrees, Worktree, getBaseBranch } from '../utils/git';
+import { getRepoRoot, getRepoIdentityName, listWorktrees, Worktree, getBaseBranch } from '../utils/git';
 import { getActiveBackend, MultiplexerSession } from '../utils/multiplexer';
 import { toCanonicalPath } from '../utils/path';
 import { createRepoSessionPrefixConfig, matchRepoSessionName } from '../utils/sessionCompatibility';
@@ -677,7 +677,7 @@ export class TmuxSessionProvider implements vscode.TreeDataProvider<TmuxItem> {
   private async getRepoGroups(): Promise<RepoGroupItem[]> {
     try {
       const repoRoot = getRepoRoot();
-      const repoName = getRepoName(repoRoot);
+      const repoName = await getRepoIdentityName(repoRoot);
       let baseBranch: string | undefined;
       try { baseBranch = await getBaseBranch(repoRoot); } catch { /* non-git or no default branch */ }
       return [new RepoGroupItem(repoName, repoRoot, baseBranch)];
@@ -698,7 +698,7 @@ export class TmuxSessionProvider implements vscode.TreeDataProvider<TmuxItem> {
       const worktreeSlugByPath = buildWorktreeSlugMap(worktrees, repoName);
       this._error = undefined;
       const activeWorkspacePath = toCanonicalPath(repoRoot) || path.resolve(repoRoot);
-      const sessionPrefixConfig = createRepoSessionPrefixConfig(repoRoot);
+      const sessionPrefixConfig = await createRepoSessionPrefixConfig(repoRoot);
 
       const pathMap = new Map<string, { worktree?: Worktree, sessions: SessionWithStatus[], hasGit: boolean }>();
       const normalizedRepoRoot = sessionPrefixConfig.canonicalRepoRoot;

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -93,11 +93,41 @@ export function getRepoName(repoRoot: string): string {
   return path.basename(repoRoot);
 }
 
-export function getRepoSessionNamespace(repoRoot: string): string {
-  const canonicalRoot = toCanonicalPath(repoRoot) || path.resolve(repoRoot);
+export async function getPrimaryWorktreePath(repoRoot: string): Promise<string> {
+  try {
+    // Use the shared git dir to find the primary worktree, not the current one.
+    const commonDirRaw = await exec('git rev-parse --path-format=absolute --git-common-dir', { cwd: repoRoot })
+      .catch(() => exec('git rev-parse --git-common-dir', { cwd: repoRoot }));
+    const commonDir = commonDirRaw.trim();
+    if (!commonDir) return repoRoot;
+
+    const resolvedCommonDir = path.isAbsolute(commonDir)
+      ? commonDir
+      : path.resolve(repoRoot, commonDir);
+
+    return path.dirname(resolvedCommonDir);
+  } catch {
+    return repoRoot;
+  }
+}
+
+export async function getRepoIdentityRoot(repoRoot: string): Promise<string> {
+  return getPrimaryWorktreePath(repoRoot);
+}
+
+export async function getRepoIdentityName(repoRoot: string): Promise<string> {
+  return path.basename(await getRepoIdentityRoot(repoRoot));
+}
+
+export function getRepoSessionNamespaceForRoot(identityRoot: string): string {
+  const canonicalRoot = toCanonicalPath(identityRoot) || path.resolve(identityRoot);
   const repoName = getActiveBackend().sanitizeSessionName(path.basename(canonicalRoot) || 'repo');
   const rootHash = createHash('sha1').update(canonicalRoot).digest('hex').slice(0, 8);
   return `${repoName}-${rootHash}`;
+}
+
+export async function getRepoSessionNamespace(repoRoot: string): Promise<string> {
+  return getRepoSessionNamespaceForRoot(await getRepoIdentityRoot(repoRoot));
 }
 
 // Determine base branch by checking common default branch names in order
@@ -136,12 +166,12 @@ export function getManagedWorktreesRoot(): string {
   return path.join(os.homedir(), '.tmux-worktrees');
 }
 
-export function getManagedRepoWorktreesDir(repoRoot: string): string {
-  return path.join(getManagedWorktreesRoot(), getRepoSessionNamespace(repoRoot));
+export async function getManagedRepoWorktreesDir(repoRoot: string): Promise<string> {
+  return path.join(getManagedWorktreesRoot(), await getRepoSessionNamespace(repoRoot));
 }
 
-export function isManagedWorktreePath(repoRoot: string, worktreePath: string): boolean {
-  const managedDir = toCanonicalPath(getManagedRepoWorktreesDir(repoRoot));
+export async function isManagedWorktreePath(repoRoot: string, worktreePath: string): Promise<boolean> {
+  const managedDir = toCanonicalPath(await getManagedRepoWorktreesDir(repoRoot));
   const candidatePath = toCanonicalPath(worktreePath);
   if (!managedDir || !candidatePath) return false;
   return candidatePath === managedDir || candidatePath.startsWith(`${managedDir}${path.sep}`);
@@ -149,28 +179,11 @@ export function isManagedWorktreePath(repoRoot: string, worktreePath: string): b
 
 // Ensure the managed worktree directory exists.
 export async function ensureWorktreesDir(repoRoot: string): Promise<string> {
-  const worktreesDir = getManagedRepoWorktreesDir(repoRoot);
+  const worktreesDir = await getManagedRepoWorktreesDir(repoRoot);
   if (!fs.existsSync(worktreesDir)) {
     await fs.promises.mkdir(worktreesDir, { recursive: true });
   }
   return worktreesDir;
-}
-
-async function getMainWorktreePath(repoRoot: string): Promise<string> {
-  try {
-    // Use the shared git dir to find the primary worktree, not the current one.
-    const commonDirRaw = await exec('git rev-parse --git-common-dir', { cwd: repoRoot });
-    const commonDir = commonDirRaw.trim();
-    if (!commonDir) return repoRoot;
-
-    const resolvedCommonDir = path.isAbsolute(commonDir)
-      ? commonDir
-      : path.resolve(repoRoot, commonDir);
-
-    return path.dirname(resolvedCommonDir);
-  } catch {
-    return repoRoot;
-  }
 }
 
 // worktree 목록 조회 (prunable 제외)
@@ -179,7 +192,7 @@ export async function listWorktrees(repoRoot: string): Promise<Worktree[]> {
     const output = await exec('git worktree list --porcelain', { cwd: repoRoot });
     const worktrees: Worktree[] = [];
     const blocks = output.split('\n\n').filter(b => b.trim());
-    const mainWorktreePath = await getMainWorktreePath(repoRoot);
+    const mainWorktreePath = await getPrimaryWorktreePath(repoRoot);
     const normalizedMainWorktreePath = toCanonicalPath(mainWorktreePath) || path.resolve(mainWorktreePath);
     
     for (const block of blocks) {

--- a/src/utils/sessionCompatibility.ts
+++ b/src/utils/sessionCompatibility.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { getRepoName, getRepoSessionNamespace } from './git';
+import { getRepoIdentityRoot, getRepoSessionNamespaceForRoot } from './git';
 import { toCanonicalPath } from './path';
 import { getActiveBackend } from './multiplexer';
 
@@ -13,10 +13,11 @@ export interface RepoSessionPrefixConfig {
   legacyPrefix: string;
 }
 
-export function createRepoSessionPrefixConfig(repoRoot: string): RepoSessionPrefixConfig {
-  const canonicalRepoRoot = toCanonicalPath(repoRoot) || path.resolve(repoRoot);
-  const repoName = getRepoName(repoRoot);
-  const repoSessionNamespace = getRepoSessionNamespace(repoRoot);
+export async function createRepoSessionPrefixConfig(repoRoot: string): Promise<RepoSessionPrefixConfig> {
+  const identityRoot = await getRepoIdentityRoot(repoRoot);
+  const canonicalRepoRoot = toCanonicalPath(identityRoot) || path.resolve(identityRoot);
+  const repoName = path.basename(identityRoot);
+  const repoSessionNamespace = getRepoSessionNamespaceForRoot(identityRoot);
 
   return {
     repoName,


### PR DESCRIPTION
## Summary
- Fixes #6 by anchoring session namespace and managed worktree directories to the primary worktree instead of the current VS Code workspace folder.
- Updates commands/providers to await the shared repo identity helpers and keeps current workspace detection separate.
- Documents the behavior and excludes local `.omx/` state from VSIX packages.

## Root cause
Opening VS Code from a linked worktree changed `getRepoRoot()` to that worktree path. Session namespace hashing used that path directly, so session names shifted from `project-<hash>_task` to `task-<hash>_task`.

## Validation
- `npm run compile`
- `npm run lint`
- Temp git repo smoke verified main worktree and linked worktree produce the same namespace and managed worktree dir.
- `npx --yes @vscode/vsce package --no-dependencies --out /tmp/vscode-tmux-worktree-1.2.13.vsix` confirmed `.omx/` is absent from the package.
- Installed packaged VSIX into `code` and `code-insiders`.

## Not tested
- Manual VS Code UI attach flow.
- Antigravity install: `/usr/local/bin/antigravity` is a broken symlink to missing `/Applications/Antigravity.app/...`.
