### PR TITLE
[codex] Split Open VSX publishing into companion workflow

### DIFF
--- a/.github/workflows/publish-open-vsx.yml
+++ b/.github/workflows/publish-open-vsx.yml
@@ -1,0 +1,64 @@
+name: Publish Open VSX
+
+on:
+  workflow_run:
+    workflows: ["Publish Extension"]
+    types: [completed]
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version label for the manually packaged VSIX (defaults to package.json version)"
+        required: false
+        type: string
+
+concurrency:
+  group: publish-open-vsx-${{ github.event.workflow_run.id || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-open-vsx:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download VSIX from marketplace publish workflow
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: gh run download "$RUN_ID" --name vscode-tmux-worktree-vsix --dir dist
+
+      - name: Checkout for manual publish
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js for manual publish
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build VSIX for manual publish
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          npm ci
+          npm run compile
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(node -p "require('./package.json').version")
+          fi
+          mkdir -p dist
+          npx @vscode/vsce package --out "dist/vscode-tmux-worktree-${VERSION}.vsix"
+
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: npx --yes ovsx -p "$OVSX_PAT" publish --skip-duplicate dist/*.vsix

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,7 @@ jobs:
             esac
             
             VERSION="${MAJOR}.${MINOR}.${PATCH}"
-            npm version $VERSION --no-git-tag-version
+            npm version "$VERSION" --no-git-tag-version
             
             git add package.json package-lock.json
             git commit -m "chore: release v${VERSION}"
@@ -87,7 +87,7 @@ jobs:
             git push origin "v${VERSION}"
           fi
           
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Compile
         run: npm run compile
@@ -95,13 +95,16 @@ jobs:
       - name: Package VSIX
         run: npx @vscode/vsce package --out "vscode-tmux-worktree-${{ steps.version.outputs.version }}.vsix"
 
-      - name: Publish to VS Code Marketplace
-        run: npx @vscode/vsce publish -p ${{ secrets.VSCE_PAT }}
-        continue-on-error: false
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-tmux-worktree-vsix
+          path: vscode-tmux-worktree-${{ steps.version.outputs.version }}.vsix
+          if-no-files-found: error
 
-      - name: Publish to Open VSX
-        run: npx ovsx publish "vscode-tmux-worktree-${{ steps.version.outputs.version }}.vsix" -p ${{ secrets.OVSX_PAT }}
-        continue-on-error: true
+      - name: Publish to VS Code Marketplace
+        run: npx @vscode/vsce publish --packagePath "vscode-tmux-worktree-${{ steps.version.outputs.version }}.vsix" -p ${{ secrets.VSCE_PAT }}
+        continue-on-error: false
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ This document serves as the primary rule file for AI Agents working on this proj
 - **Zellij Control-Key Passthroughs**: Use literal control/escape sequences in `ZELLIJ_KEY_PASSTHROUGHS` so VS Code forwards the intended byte to the terminal. Prefer scan-code key strings for control and Alt shortcuts so Korean IME/layout variants map to the intended physical key without duplicate Hangul-specific bindings.
 - **No-Git Workspace Labeling**: If the workspace is not a git worktree, the tree must still show one primary item labeled `current project (no git)` mapped to the current workspace path.
 - **Package Hygiene**: Keep local orchestration/runtime state such as `.omx/` out of VSIX packages via `.vscodeignore`; git excludes alone do not affect packaging.
+- **Marketplace Publishing**: `publish.yml` owns version bump, VSIX packaging, VS Code Marketplace publishing, and GitHub releases. Open VSX publishing lives in `publish-open-vsx.yml` and consumes the uploaded VSIX artifact from the successful marketplace workflow so both registries receive the same package.
 
 ## 3. Documentation & Development
 


### PR DESCRIPTION
## Summary
- Adds a dedicated `Publish Open VSX` workflow that runs after the `Publish Extension` workflow succeeds on `main`.
- Uploads the marketplace VSIX from `publish.yml` and has Open VSX consume that same artifact.
- Removes the inline best-effort Open VSX step from the marketplace workflow so Open VSX failures are isolated and retryable.
- Documents the publishing ownership split in `AGENTS.md`.

## Secrets
- Added/updated repository Actions secret `OVSX_PAT`.

## Validation
- `actionlint .github/workflows/publish.yml .github/workflows/publish-open-vsx.yml`
- `npm run compile`
- `npm run lint`
- `npx --yes @vscode/vsce package --no-dependencies --out /tmp/vscode-tmux-worktree-1.2.13.vsix`
- Installed packaged VSIX into `code` and `code-insiders`.

## Not tested
- End-to-end `workflow_run` after merge.
- Antigravity install: `/usr/local/bin/antigravity` is a broken symlink to missing `/Applications/Antigravity.app/...`.

## Merge note
Merging to `main` may trigger the existing release workflow because `publish.yml` listens to pushes on `main`.
